### PR TITLE
Multi parameters

### DIFF
--- a/src/paginator.js
+++ b/src/paginator.js
@@ -81,7 +81,8 @@ export class OpenSearchPaginator {
                                  preferStartIndex = true,
                                  baseOffset = 0,
                                  maxUrlLength = undefined,
-                                 parseOptions = undefined } = {}) {
+                                 parseOptions = undefined,
+                                 headers = undefined } = {}) {
     this._url = url;
     this._parameters = parameters;
     this._cache = useCache ? {} : null;
@@ -92,6 +93,7 @@ export class OpenSearchPaginator {
     this._serverItemsPerPage = undefined;
     this._totalResults = undefined;
     this._parseOptions = parseOptions;
+    this._headers = headers;
   }
 
   /**
@@ -127,14 +129,15 @@ export class OpenSearchPaginator {
     } else {
       parameters.startPage = pageIndex + this._url.pageOffset;
     }
-    return search(this._url, parameters, null, false, this._maxUrlLength, this._parseOptions)
-      .then((result) => {
-        this._totalResults = result.totalResults;
-        if (!this._serverItemsPerPage && result.itemsPerPage) {
-          this._serverItemsPerPage = result.itemsPerPage;
-        }
-        return result;
-      });
+    return search(
+      this._url, parameters, null, false, this._maxUrlLength, this._parseOptions, this._headers
+    ).then((result) => {
+      this._totalResults = result.totalResults;
+      if (!this._serverItemsPerPage && result.itemsPerPage) {
+        this._serverItemsPerPage = result.itemsPerPage;
+      }
+      return result;
+    });
   }
 
   /**
@@ -199,7 +202,8 @@ export class OpenSearchPaginator {
           );
 
         // determine the number of pages and issue a request for each
-        const numPages = firstPage.itemsPerPage ? Math.ceil(usedMaxCount / firstPage.itemsPerPage) : 1;
+        const numPages = firstPage.itemsPerPage ?
+          Math.ceil(usedMaxCount / firstPage.itemsPerPage) : 1;
         for (let i = 1; i < numPages; ++i) {
           let count = firstPage.itemsPerPage;
           if (firstPage.itemsPerPage * (i + 1) > usedMaxCount) {
@@ -264,7 +268,8 @@ export class OpenSearchPaginator {
           ) : firstPage.totalResults;
 
         // determine the number of pages and issue a request for each
-        const numPages = firstPage.itemsPerPage ? Math.ceil(usedMaxCount / firstPage.itemsPerPage) : 1;
+        const numPages = firstPage.itemsPerPage ?
+          Math.ceil(usedMaxCount / firstPage.itemsPerPage) : 1;
         for (let i = 1; i < numPages; ++i) {
           let count = firstPage.itemsPerPage;
           if (firstPage.itemsPerPage * (i + 1) > usedMaxCount) {

--- a/src/search.js
+++ b/src/search.js
@@ -28,7 +28,7 @@ import { config } from './config';
  * @param {object} parameterValues The search parameter values.
  * @returns {module:opensearch/search.BaseRequest} The constructed base request object.
  */
-export function createBaseRequest(url, parameterValues) {
+export function createBaseRequest(url, parameterValues, headers) {
   // check parameters
   Object.keys(parameterValues).forEach((key) => {
     if (!Object.prototype.hasOwnProperty.call(url._parametersByType, key)
@@ -60,6 +60,7 @@ export function createBaseRequest(url, parameterValues) {
     return {
       method: url.method,
       url: urlString,
+      headers,
     };
   }
 
@@ -94,11 +95,13 @@ export function createBaseRequest(url, parameterValues) {
  * @param {string} [type=null] The response format.
  * @param {boolean} [raw=false] Whether the response shall be parsed or returned raw.
  * @param {number} [maxUrlLength=undefined] The maximum URL length. URLs longer than that
-                                            will result in errors.
+ *                                          will result in errors.
+ * @param {object} [parseOptions=undefined] Additional options for the format.
+ * @param {object} [headers=undefined] Specific headers to send to the service.
  * @returns {Promise<SearchResult>|Promise<Response>} The search result as a Promise
  */
-export function search(url, parameters = {}, type = null, raw = false, maxUrlLength = undefined, parseOptions = undefined) {
-  const baseRequest = createBaseRequest(url, parameters);
+export function search(url, parameters = {}, type, raw, maxUrlLength, parseOptions, headers) {
+  const baseRequest = createBaseRequest(url, parameters, headers);
   const { useXHR } = config();
 
   if (typeof maxUrlLength !== 'undefined' && baseRequest.url.length > maxUrlLength) {

--- a/src/service.js
+++ b/src/service.js
@@ -51,7 +51,7 @@ export class OpenSearchService {
         if (missingParamNames.length) {
           terms.push(`missing parameters: ${missingParamNames.join(', ')}`);
         }
-        if (unsupportedParameterKeys) {
+        if (unsupportedParameterKeys.length) {
           terms.push(`unsupported parameters keys: ${unsupportedParameterKeys.join(', ')}`);
         }
         throw new Error(`No matching URL found, ${terms.join(' and ')}`);

--- a/src/service.js
+++ b/src/service.js
@@ -99,10 +99,12 @@ export class OpenSearchService {
    * @param {string} [method=null] The preferred HTTP method type.
    * @param {boolean} [raw=false] Whether the response shall be parsed or returned raw.
    * @param {number} [maxUrlLength=undefined] The maximum URL length. URLs longer than that
-                                              will result in errors.
+   *                                          will result in errors.
+   * @param {object} [parseOptions=undefined] Additional options for the format.
+   * @param {object} [headers=undefined] Specific headers to send to the service.
    * @returns {Promise<array>|Promise<Response>} The search result as a Promise
    */
-  search(parameters, type = null, method = null, raw = false, maxUrlLength = undefined) {
+  search(parameters, type = null, method = null, raw = false, maxUrlLength, parseOptions, headers) {
     let url = null;
     if (!type) {
       // try to find a suitable URL
@@ -120,9 +122,8 @@ export class OpenSearchService {
       url = this.getUrl(parameters, type, method);
     }
 
-    return search(url, parameters, type, raw, maxUrlLength);
+    return search(url, parameters, type, raw, maxUrlLength, parseOptions, headers);
   }
-
 
   /**
    * Gets the suggestions for the current search parameters.

--- a/src/url.js
+++ b/src/url.js
@@ -246,7 +246,14 @@ export class OpenSearchUrl {
           serialized.push([parameter.name, type, value]);
         }
       } else {
-        const value = parameter.serializeValue(values[parameter.name] || values[parameter.type] || '');
+        let value;
+        if (Object.prototype.hasOwnProperty.call(values, parameter.name)) {
+          value = parameter.serializeValue(values[parameter.name]);
+        } else if (Object.prototype.hasOwnProperty.call(values, parameter.type)) {
+          value = parameter.serializeValue(values[parameter.type]);
+        } else {
+          value = '';
+        }
         serialized.push([parameter.name, parameter.type, value]);
       }
     }

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-expressions */
+/* eslint-disable no-useless-escape */
 
 import { expect } from 'chai';
 import { OpenSearchParameter } from '../src/parameter';
@@ -17,6 +18,7 @@ describe('OpenSearchParameter', () => {
     const paramGeometry = OpenSearchParameter.fromKeyValuePair('geometry', '{geo:geometry}');
     const paramEONumeric = OpenSearchParameter.fromKeyValuePair('orbitNumber', '{eo:orbitNumber}');
     const paramEODate = OpenSearchParameter.fromKeyValuePair('creationDate', '{eo:creationDate}');
+    const paramMultiTemplateOptional = OpenSearchParameter.fromKeyValuePair('timespan', '{time:start?}/{time:end?}');
 
     const paramDateWithPatternNoMS = OpenSearchParameter.fromNode(
       parseXml(
@@ -116,12 +118,18 @@ describe('OpenSearchParameter', () => {
     it('shall throw when no pattern could be decoded', () => {
       expect(paramDateWithUnknownPattern.serializeValue(new Date('2000-01-02T01:01:01Z'))).to.equal('2000-01-02T01:01:01.000Z');
     });
+
+    it('shall work with multi params and templates', () => {
+      expect(paramMultiTemplateOptional.serializeValue(new Date('2000-01-02T01:01:01Z'), 'time:start')).to.equal('2000-01-02T01:01:01.000Z');
+      expect(paramMultiTemplateOptional.serializeValue(new Date('2000-01-03T01:01:01Z'), 'time:end')).to.equal('2000-01-03T01:01:01.000Z');
+    });
   });
 
   describe('fromKeyValuePair', () => {
     const paramMandatory = OpenSearchParameter.fromKeyValuePair('q', '{searchTerms}');
     const paramOptional = OpenSearchParameter.fromKeyValuePair('start', '{startIndex?}');
     const paramIgnored = OpenSearchParameter.fromKeyValuePair('format', 'rss');
+    const paramMultiTemplateOptional = OpenSearchParameter.fromKeyValuePair('timespan', '{time:start?}/{time:end?}');
 
     it('should work for mandatory parameters', () => {
       expect(paramMandatory.name).to.equal('q');
@@ -137,6 +145,12 @@ describe('OpenSearchParameter', () => {
 
     it('should ignore parameters when the value is not right', () => {
       expect(paramIgnored).to.be.null;
+    });
+
+    it('should work with templates and multiple values at once', () => {
+      expect(paramMultiTemplateOptional.name).to.equal('timespan');
+      expect(paramMultiTemplateOptional.type).to.deep.equal(['time:start', 'time:end']);
+      expect(paramMultiTemplateOptional.mandatory).to.be.false;
     });
   });
 

--- a/test/url.js
+++ b/test/url.js
@@ -57,6 +57,35 @@ describe('OpenSearchUrl', () => {
     });
   });
 
+
+  describe('serializeValues', () => {
+    const xml = `<os:Url
+      type="application/atom+xml"
+      template="http://demo.pycsw.org/cite/csw?mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/atom+xml&amp;&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>`;
+    const url = OpenSearchUrl.fromNode(parseXml(xml).documentElement);
+
+    it('shall serialize values', () => {
+      const serialized = url.serializeValues({
+        searchTerms: 'terms',
+        'geo:box': [0, 0, 1, 1],
+        'time:start': new Date('2001-01-01T00:00:00Z'),
+        'time:end': new Date('2002-01-01T00:00:00Z'),
+        'geo:uid': 'someuid',
+        // startIndex and count are intentionally left empty
+      });
+
+      expect(serialized).to.deep.equal([
+        ['q', 'searchTerms', 'terms'],
+        ['bbox', 'geo:box', '0,0,1,1'],
+        ['time', 'time:start', '2001-01-01T00:00:00.000Z'],
+        ['time', 'time:end', '2002-01-01T00:00:00.000Z'],
+        ['startposition', 'startIndex', ''],
+        ['maxrecords', 'count', ''],
+        ['recordids', 'geo:uid', 'someuid'],
+      ]);
+    });
+  });
+
   /* TODO: this was moved to a separate file
   describe('#createRequest', () => {
     const urlGet = OpenSearchUrl.fromTemplateUrl(

--- a/test/url.js
+++ b/test/url.js
@@ -60,6 +60,7 @@ describe('OpenSearchUrl', () => {
 
   describe('serializeValues', () => {
     const xml = `<os:Url
+      xmlns:os="http://a9.com/-/spec/opensearch/1.1/"
       type="application/atom+xml"
       template="http://demo.pycsw.org/cite/csw?mode=opensearch&amp;service=CSW&amp;version=3.0.0&amp;request=GetRecords&amp;elementsetname=full&amp;typenames=csw:Record&amp;resulttype=results&amp;q={searchTerms?}&amp;bbox={geo:box?}&amp;time={time:start?}/{time:end?}&amp;outputformat=application/atom+xml&amp;&amp;startposition={startIndex?}&amp;maxrecords={count?}&amp;recordids={geo:uid}"/>`;
     const url = OpenSearchUrl.fromNode(parseXml(xml).documentElement);


### PR DESCRIPTION
Implementing support for parameters where the parameter value is composed of more than one template value, e.g: `timespan={time:start?}/{time:end?}`